### PR TITLE
Expose belCreateElement function in module

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var SVG_TAGS = [
   'tspan', 'use', 'view', 'vkern'
 ]
 
-module.exports = hyperx(function bel (tag, props, children) {
+function belCreateElement (tag, props, children) {
   var el
 
   // If an svg tag, it needs a namespace
@@ -109,4 +109,7 @@ module.exports = hyperx(function bel (tag, props, children) {
   appendChild(children)
 
   return el
-})
+}
+
+module.exports = hyperx(belCreateElement)
+module.exports.createElement = belCreateElement


### PR DESCRIPTION
It's handy to be able to access to bel's element creation function so that you can compose it with other hyperx processing. For example, a few hacks from this weekend:

* https://github.com/chromakode/diablo/blob/83ec0357df45a4e465d6832f4e77d7f25c033ab0/index.js#L12
* https://github.com/chromakode/yo-yo/blob/1dcdde259d2b34d20f8b2978f347a99098f63e8a/index.js#L7

I think it'd make sense to call this `bel.createElement` while retaining the current hyperx default export. What do you think?