### PR TITLE
Combine adjacent text nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ function belCreateElement (tag, props, children) {
       }
 
       if (typeof node === 'string') {
+        if (el.lastChild && el.lastChild.nodeName === '#text') {
+          el.lastChild.nodeValue += node
+          continue
+        }
         node = document.createTextNode(node)
       }
 

--- a/test/elements.js
+++ b/test/elements.js
@@ -59,3 +59,13 @@ test('style', function (t) {
   t.equal(result.querySelector('span').style.color, 'blue', 'set style color on child')
   t.end()
 })
+
+test('adjacent text nodes', function (t) {
+  t.plan(2)
+  var who = 'world'
+  var exclamation = ['!', ' :)']
+  var result = bel`<div>hello ${who}${exclamation}</div>`
+  t.equal(result.childNodes.length, 1, 'should be merged')
+  t.equal(result.outerHTML, '<div>hello world! :)</div>', 'should have correct output')
+  t.end()
+})


### PR DESCRIPTION
This improves symmetry with inner/outerHTML, which makes diffing via `morphdom` more efficient.

Consider this example:

```js
var who = 'world'
var exclamation = ['!', ':)']
bel`<div>hello ${who}${exclamation}`
```

`hyperx` passes bel: `tag: 'div', props: Object{}, children: ['hello ', 'world', ['!', ' :)']]`

Currently, `bel` creates a separate text node for each string (illustrated w/ newlines):

```
<div>
  hello
  world
  !
  :)
</div>
```

If we take that output and then stringify the tree via `outerHTML`, the text nodes are effectively merged together.

Thus, if we use `morphdom` to diff a tree generated by `bel` with the same output fetched from an html file, nodes currently get unnecessarily removed and recreated because the trees don't match up.

It turns out to be pretty easy to just merge the text nodes up as we build the tree. This approach covers nested arrays of strings (tested by the included test). Not sure of perf impact of the extra concatenations, but I think this behavior is more correct and will help avoid some DOM thrashing in `yo-yo`.