### PR TITLE
support xlink attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var document = require('global/document')
 var hyperx = require('hyperx')
 
 var SVGNS = 'http://www.w3.org/2000/svg'
+var XLINKNS = 'http://www.w3.org/1999/xlink'
+
 var BOOL_PROPS = {
   autofocus: 1,
   checked: 1,
@@ -77,7 +79,11 @@ function belCreateElement (tag, props, children) {
         el[p] = val
       } else {
         if (ns) {
-          el.setAttributeNS(null, p, val)
+          if (p === 'xlink:href') {
+            el.setAttributeNS(XLINKNS, p, val)
+          } else {
+            el.setAttributeNS(null, p, val)
+          }
         } else {
           el.setAttribute(p, val)
         }

--- a/test/elements.js
+++ b/test/elements.js
@@ -42,12 +42,14 @@ test('can update and submit inputs', function (t) {
 })
 
 test('svg', function (t) {
-  t.plan(2)
+  t.plan(3)
   var result = bel`<svg width="150" height="100" viewBox="0 0 3 2">
     <rect width="1" height="2" x="0" fill="#008d46" />
+    <use xlink:href="#test" />
   </svg>`
   t.equal(result.tagName, 'svg', 'create svg tag')
   t.equal(result.childNodes[1].tagName, 'rect', 'created child rect tag')
+  t.equal(result.childNodes[3].getAttribute('xlink:href'), '#test', 'created child use tag with xlink:href')
   t.end()
 })
 


### PR DESCRIPTION
Hi! 🐈 

I got Error when I try it through choo 🚋  this below:
```
Uncaught NamespaceError: Uncaught NamespaceError: Failed to execute 'setAttributeNS' on 'Element': '' is an invalid namespace for attributes.
```

minimal case is:
```js
bel`<use xlink:href="#test"></use>`
```

http://requirebin.com/?gist=46114442a147e543dc2ba48ead547fc6


To use `xlink`, we need to `setAttributeNS('http://www.w3.org/1999/xlink', ...`

Thanks:smile: