### PR TITLE
Add onload/onunload lifecycle properties. Fixes GH-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ module.exports = function (bears) {
 }
 ```
 
+### lifecycle events
+
+Use the `onload` and `onunload` properties to call a function when the element
+is inserted and removed from the DOM respectively.
+
+```js
+var bel = require('bel')
+
+var modal = bel`<div onload=${function () {
+  console.log('Hello DOM!')
+}} onunload=${function () {
+  console.log('Goodbye DOM!')
+}}>hello!</div>`
+
+document.body.appendChild(modal)
+document.body.removeChild(modal)
+```
+
 ### use with/without [hyperx](https://www.npmjs.com/package/hyperx)
 
 `hyperx` is built into `bel` but there may be times when you wish to use your

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ is inserted and removed from the DOM respectively.
 ```js
 var bel = require('bel')
 
-var modal = bel`<div onload=${function () {
+var modal = bel`<div onload=${function (element) {
   console.log('Hello DOM!')
-}} onunload=${function () {
+}} onunload=${function (element) {
   console.log('Goodbye DOM!')
 }}>hello!</div>`
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var document = require('global/document')
 var hyperx = require('hyperx')
+var onload = require('on-load')
 
 var SVGNS = 'http://www.w3.org/2000/svg'
 var BOOL_PROPS = {
@@ -51,6 +52,19 @@ function belCreateElement (tag, props, children) {
     el = document.createElementNS(ns, tag)
   } else {
     el = document.createElement(tag)
+  }
+
+  // If adding onload events
+  if (props.onload || props.onunload) {
+    var load = props.onload
+    var unload = props.onunload
+    onload(el, function bel_onload () {
+      load(el)
+    }, function bel_onunload () {
+      unload(el)
+    })
+    delete props.onload
+    delete props.onunload
   }
 
   // Create the properties

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/shama/bel",
   "dependencies": {
     "global": "^4.3.0",
-    "hyperx": "^2.0.2"
+    "hyperx": "^2.0.2",
+    "on-load": "^2.1.1"
   },
   "devDependencies": {
     "browser-process-hrtime": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "global": "^4.3.0",
     "hyperx": "^2.0.2",
-    "on-load": "^2.1.1"
+    "on-load": "^3.0.0"
   },
   "devDependencies": {
     "browser-process-hrtime": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "browserify": "^13.0.0",
     "electron-prebuilt": "^0.36.9",
     "standard": "^6.0.7",
-    "tape": "^4.5.0",
+    "tape": "^4.6.0",
     "testron": "^1.2.0",
-    "wzrd": "^1.3.1"
+    "wzrd": "^1.4.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./api.js')
 require('./elements.js')
+require('./onload.js')

--- a/test/onload.js
+++ b/test/onload.js
@@ -1,0 +1,18 @@
+var test = require('tape')
+var bel = require('../')
+var document = require('global/document')
+
+test('first onload and unload events', function (t) {
+  t.plan(2)
+  var el = bel`<div onload=${function () {
+    t.equal(el.textContent, 'hi', 'fired onload')
+  }} onunload=${function () {
+    t.equal(el.textContent, 'hi', 'fired onunload')
+    t.end()
+  }}>hi</div>`
+  var result = bel`<div>
+    ${el}
+  </div>`
+  document.body.appendChild(result)
+  document.body.removeChild(result)
+})

--- a/test/onload.js
+++ b/test/onload.js
@@ -2,16 +2,16 @@ var test = require('tape')
 var bel = require('../')
 var document = require('global/document')
 
-test('first onload and unload events', function (t) {
+test('fire onload and unload events', function (t) {
   t.plan(2)
-  var el = bel`<div onload=${function () {
+  var element = bel`<div onload=${function (el) {
     t.equal(el.textContent, 'hi', 'fired onload')
-  }} onunload=${function () {
+  }} onunload=${function (el) {
     t.equal(el.textContent, 'hi', 'fired onunload')
     t.end()
   }}>hi</div>`
   var result = bel`<div>
-    ${el}
+    ${element}
   </div>`
   document.body.appendChild(result)
   document.body.removeChild(result)


### PR DESCRIPTION
@yoshuawuyts Take a look please? :)

I'm just calling the function instead of actually creating a custom event because: (a) cross browser custom events are lengthy (b) users can still attach `el.addEventListener('load')` if they for some reason setup `load` or `unload` as a custom event on the element.

Shouldn't be too hard to implement into `yo-yoify` either :) Thanks!