### PR TITLE
Add "security" README section with XSS notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ var element = bel`<div class="heading">Hello!</div>`
 var sameElement = createElement('div', { className: 'heading' }, ['Hello!'])
 ```
 
+## security
+
+bel sets attributes with `element.setAttribute()` and `element.setAttributeNS()`, and creates text nodes with `document.createTextNode()`.  These approaches mitigate some [Cross-Site Scripting (XSS)](https://www.owasp.org/index.php/Cross-site_Scripting_%28XSS%29) attacks.  You should still code carefully every time you put content from users in the DOM.
+
 ## similar projects
 
 * [vel](https://github.com/yoshuawuyts/vel)  


### PR DESCRIPTION
Thanks for bel!  I have had a great time using it for <https://commonform.org>.

This small doc patch adds a short "security" question with a few notes on XSS mitigation.  I dug into the code and rummaged around GitHub issues to see what, if anything, bel does in terms of escaping and containment.  I imagine this short note may save others the trouble.

Best,

K