### PR TITLE
Adds support for `xlink` attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,21 +36,8 @@ var SVG_TAGS = [
 function belCreateElement (tag, props, children) {
   var el
 
-  // If an svg tag, it needs a namespace
   if (SVG_TAGS.indexOf(tag) !== -1) {
-    props.namespace = SVGNS
-  }
-
-  // If we are using a namespace
-  var ns = false
-  if (props.namespace) {
-    ns = props.namespace
-    delete props.namespace
-  }
-
-  // Create the element
-  if (ns) {
-    el = document.createElementNS(ns, tag)
+    el = document.createElementNS(SVGNS, tag)
   } else {
     el = document.createElement(tag)
   }
@@ -93,11 +80,7 @@ function belCreateElement (tag, props, children) {
       if (key.slice(0, 2) === 'on') {
         el[p] = val
       } else {
-        if (ns) {
-          el.setAttributeNS(null, p, val)
-        } else {
-          el.setAttribute(p, val)
-        }
+        el.setAttribute(p, val)
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -59,9 +59,9 @@ function belCreateElement (tag, props, children) {
   if (props.onload || props.onunload) {
     var load = props.onload || function () {}
     var unload = props.onunload || function () {}
-    onload(el, function bel_onload () {
+    onload(el, function belOnload () {
       load(el)
-    }, function bel_onunload () {
+    }, function belOnunload () {
       unload(el)
     },
     // We have to use non-standard `caller` to find who invokes `belCreateElement`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/shama/bel",
   "dependencies": {
-    "global": "^4.3.0",
+    "global": "^4.3.1",
     "hyperx": "^2.0.2",
     "on-load": "^3.2.0"
   },

--- a/test/elements.js
+++ b/test/elements.js
@@ -42,12 +42,20 @@ test('can update and submit inputs', function (t) {
 })
 
 test('svg', function (t) {
-  t.plan(2)
-  var result = bel`<svg width="150" height="100" viewBox="0 0 3 2">
-    <rect width="1" height="2" x="0" fill="#008d46" />
-  </svg>`
+  t.plan(3)
+  var result = bel`
+    <svg
+      width="150"
+      height="100"
+      viewBox="0 0 3 2"
+    >
+      <rect width="1" height="2" x="0" fill="#008d46" />
+      <use xlink:href="#test" />
+    </svg>
+  `
   t.equal(result.tagName, 'svg', 'create svg tag')
   t.equal(result.childNodes[1].tagName, 'rect', 'created child rect tag')
+  t.equal(result.childNodes[3].getAttribute('xlink:href'), '#test', 'created child use tag with xlink:href')
   t.end()
 })
 


### PR DESCRIPTION
After some research, it turns out that `setAttributeNS` is not needed for namespaced attributes like `xlink:href`
[For setting attributes that have a namespace, it is recommended (but not required) that you also include their prefix in the second argument](https://developer.mozilla.org/en-US/docs/Web/SVG/Namespaces_Crash_Course)

This makes the tests pass without hardcoding anything.