### PR TITLE
Set object and function properties directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ function belCreateElement (tag, props, children) {
     if (props.hasOwnProperty(p)) {
       var key = p.toLowerCase()
       var val = props[p]
+      var valType = typeof val
       // Normalize className
       if (key === 'classname') {
         key = 'class'
@@ -92,7 +93,7 @@ function belCreateElement (tag, props, children) {
         else if (val === 'false') continue
       }
       // If a property prefers being set directly vs setAttribute
-      if (key.slice(0, 2) === 'on') {
+      if (key.slice(0, 2) === 'on' || (valType === 'object' || valType === 'function')) {
         el[p] = val
       } else {
         if (ns) {

--- a/test/elements.js
+++ b/test/elements.js
@@ -81,3 +81,16 @@ test('for attribute is set correctly', function (t) {
   t.ok(result.outerHTML.indexOf('<label for="heyo">label</label>') !== -1, 'contains for="heyo"')
   t.end()
 })
+
+test('object and function properties are set directly', function (t) {
+  t.plan(5)
+  var foo = 'lol'
+  var bar = { a: 1 }
+  var baz = function () { return 'woah' }
+  var result = bel`<div foo=${foo} bar=${bar} baz=${baz}></div>`
+  t.equal(result.getAttribute('foo'), foo, 'string property set as attribute')
+  t.notOk(result.foo, 'string property not set directly')
+  t.equal(result.bar, bar, 'object property set directly')
+  t.equal(result.baz, baz, 'function property set directly')
+  t.equal(result.baz(), 'woah', 'function property evaluates')
+})


### PR DESCRIPTION
Had an idea this afternoon and was surprisingly simple to implement. Wanted to get folks' thoughts.

This allows you to pass objects and functions as if they were attributes, and they'll be set directly on the element rather than as an attribute, which would convert them to a string (rendering them useless). There's probably some utility for this on regular elements, but there'd be a lot of utility with custom elements.

``` javascript
const html = require('bel')

const foo = 'lol'
const bar = { a: 1 }
const baz = () => 'woah'

const tree = html`<div foo=${foo} bar=${bar} baz=${baz}></div>`

console.log(tree.getAttribute('foo')) // lol
console.log(tree.bar) // Object {a: 1}
console.log(tree.baz) // () => 'woah'
console.log(tree.baz()) // 'woah'
```
