### PR TITLE
Call toString on functions as children

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ function belCreateElement (tag, props, children) {
 
       if (typeof node === 'number' ||
         typeof node === 'boolean' ||
+        typeof node === 'function' ||
         node instanceof Date ||
         node instanceof RegExp) {
         node = node.toString()


### PR DESCRIPTION
As of now bel simply ignores children that are functions. This change makes bel behave the same as setting a function as `innerHTML` does:

```javascript
function noop() {}

bel`<div>${ noop }</div>` // => <div></div>

var div = document.createElement('div')
div.innerHTML = noop // => <div>function noop() {}</div>
```

My use case is pretty marginal but it makes sense that bel would behave just like `innerHTML` and treat Functions the same way it treats Number, Boolean, Date and RegExp.