### PR TITLE
Comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var BOOL_PROPS = {
   selected: 1,
   willvalidate: 1
 }
-var COMMENT_TAG = '!--';
+var COMMENT_TAG = '!--'
 var SVG_TAGS = [
   'svg',
   'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor',

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var BOOL_PROPS = {
   selected: 1,
   willvalidate: 1
 }
+var COMMENT_TAG = '!--';
 var SVG_TAGS = [
   'svg',
   'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor',
@@ -53,6 +54,8 @@ function belCreateElement (tag, props, children) {
   // Create the element
   if (ns) {
     el = document.createElementNS(ns, tag)
+  } else if (tag === COMMENT_TAG) {
+    return document.createComment(props.comment)
   } else {
     el = document.createElement(tag)
   }
@@ -144,6 +147,6 @@ function belCreateElement (tag, props, children) {
   return el
 }
 
-module.exports = hyperx(belCreateElement)
+module.exports = hyperx(belCreateElement, {comments: true})
 module.exports.default = module.exports
 module.exports.createElement = belCreateElement

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/shama/bel",
   "dependencies": {
     "global": "^4.3.0",
-    "hyperx": "^2.0.2",
+    "hyperx": "^2.3.0",
     "on-load": "^3.2.0"
   },
   "devDependencies": {

--- a/test/elements.js
+++ b/test/elements.js
@@ -79,6 +79,12 @@ test('svg with xmlns:svg', function (t) {
   t.equal(result.childNodes[1].tagName, 'rect', 'created child rect tag')
 })
 
+test('comments', function (t) {
+  var result = bel`<div><!-- this is a comment --></div>`
+  t.equal(result.outerHTML, '<div><!-- this is a comment --></div>', 'created comment')
+  t.end()
+})
+
 test('style', function (t) {
   t.plan(2)
   var name = 'test'


### PR DESCRIPTION
The pull request https://github.com/substack/hyperx/pull/44 with support for comments just got merged and here's an implementation with support in bel. The idea is that bel has comments enabled by default and you'd use [yo-yoify](https://github.com/shama/yo-yoify) to strip them out when compiling for production.

Resolves https://github.com/shama/bel/issues/41