### PR TITLE
Revert "strip empty text nodes (#68)", fixes #72 

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,6 @@ function belCreateElement (tag, props, children) {
       }
 
       if (typeof node === 'string') {
-        if (/^[\n\r\s]+$/.test(node)) continue
         if (el.lastChild && el.lastChild.nodeName === '#text') {
           el.lastChild.nodeValue += node
           continue

--- a/test/elements.js
+++ b/test/elements.js
@@ -48,8 +48,8 @@ test('svg', function (t) {
     <use xlink:href="#test" />
   </svg>`
   t.equal(result.tagName, 'svg', 'create svg tag')
-  t.equal(result.childNodes[0].tagName, 'rect', 'created child rect tag')
-  t.equal(result.childNodes[1].getAttribute('xlink:href'), '#test', 'created child use tag with xlink:href')
+  t.equal(result.childNodes[1].tagName, 'rect', 'created child rect tag')
+  t.equal(result.childNodes[3].getAttribute('xlink:href'), '#test', 'created child use tag with xlink:href')
   t.end()
 })
 
@@ -63,7 +63,7 @@ test('svg with namespace', function (t) {
   }
   t.doesNotThrow(create)
   t.equal(result.tagName, 'svg', 'create svg tag')
-  t.equal(result.childNodes[0].tagName, 'rect', 'created child rect tag')
+  t.equal(result.childNodes[1].tagName, 'rect', 'created child rect tag')
 })
 
 test('svg with xmlns:svg', function (t) {
@@ -76,7 +76,7 @@ test('svg with xmlns:svg', function (t) {
   }
   t.doesNotThrow(create)
   t.equal(result.tagName, 'svg', 'create svg tag')
-  t.equal(result.childNodes[0].tagName, 'rect', 'created child rect tag')
+  t.equal(result.childNodes[1].tagName, 'rect', 'created child rect tag')
 })
 
 test('comments', function (t) {


### PR DESCRIPTION
The empty text node between elements is significant in cases like these, where both `span` and `strong` are inline elements:

```js
require('bel')`
  <div>
    <span>Hello</span>
    <strong>${username}</strong>
  </div>
`
```

They're not significant if an element on either side of the text node is a block-level element, but I don't think that case can be detected easily and reliably