### PR TITLE
Selectively trim and collapse inter-node space

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,7 @@
 var hyperx = require('hyperx')
 
-var headRegex = /^\n[\s]+/
-var tailRegex = /\n[\s]+$/
+var leadingSpaceRegex = /^[\s]+/
+var trailingSpaceRegex = /[\s]+$/
 
 var SVGNS = 'http://www.w3.org/2000/svg'
 var XLINKNS = 'http://www.w3.org/1999/xlink'
@@ -127,20 +127,39 @@ function belCreateElement (tag, props, children) {
           el.appendChild(node)
           lastChild = node
         }
-        if (i === len - 1) {
+        // The current text node is the last child of its parent.
+        if (i === len - 1 && el.nodeName !== 'PRE') {
           hadText = false
-          var value = lastChild.nodeValue
-            .replace(headRegex, '')
-            .replace(tailRegex, '')
+          var value = i === 0
+            // If this text node is the first child of its parent and
+            // the only child of its parent, trim its leading spaces and
+            // trim its trailing spaces.
+            ? lastChild.nodeValue.trim()
+            // If this text node is the last child of its parent, but
+            // not the only child of its parent, collapse its leading
+            // spaces and trim its trailing spaces.
+            : lastChild.nodeValue
+                .replace(leadingSpaceRegex, ' ')
+                .replace(trailingSpaceRegex, '')
           if (value !== '') lastChild.nodeValue = value
           else el.removeChild(lastChild)
         }
       } else if (node && node.nodeType) {
-        if (hadText) {
+        // The current non-text node comes after a text node.
+        if (hadText && el.nodeName !== 'PRE') {
           hadText = false
-          var val = lastChild.nodeValue
-            .replace(headRegex, '')
-            .replace(tailRegex, '')
+          var val = i === 1
+            // If the prior text node is the first first of its parent,
+            // trim its leading spaces and collapse its trailing spaces.
+            ? lastChild.nodeValue
+              .replace(leadingSpaceRegex, '')
+              .replace(trailingSpaceRegex, ' ')
+            // If the prior text node is not the first child of its
+            // parent, collapse its leading spaces and collapse its
+            // trailing spaces.
+            : lastChild.nodeValue
+              .replace(leadingSpaceRegex, ' ')
+              .replace(trailingSpaceRegex, ' ')
           if (val !== '') lastChild.nodeValue = val
           else el.removeChild(lastChild)
         }

--- a/test/elements.js
+++ b/test/elements.js
@@ -49,7 +49,7 @@ test('svg', function (t) {
   </svg>`
   t.equal(result.tagName, 'svg', 'create svg tag')
   t.equal(result.childNodes[0].tagName, 'rect', 'created child rect tag')
-  t.equal(result.childNodes[1].getAttribute('xlink:href'), '#test', 'created child use tag with xlink:href')
+  t.equal(result.childNodes[2].getAttribute('xlink:href'), '#test', 'created child use tag with xlink:href')
   t.end()
 })
 
@@ -101,6 +101,53 @@ test('adjacent text nodes', function (t) {
   var result = bel`<div>hello ${who}${exclamation}</div>`
   t.equal(result.childNodes.length, 1, 'should be merged')
   t.equal(result.outerHTML, '<div>hello world! :)</div>', 'should have correct output')
+  t.end()
+})
+
+test('space in only-child text nodes', function (t) {
+  t.plan(1)
+  var result = bel`
+    <span>
+      surrounding
+      newlines
+    </span>
+  `
+  t.equal(result.outerHTML, '<span>surrounding\n      newlines</span>', 'should remove extra space')
+  t.end()
+})
+
+test('space between text and non-text nodes', function (t) {
+  t.plan(1)
+  var result = bel`
+    <div>
+      <dfn>whitespace</dfn>
+      is empty
+    </div>
+  `
+  t.equal(result.outerHTML, '<div><dfn>whitespace</dfn> is empty</div>', 'should have correct output')
+  t.end()
+})
+
+test('space between non-text nodes', function (t) {
+  t.plan(1)
+  var result = bel`
+    <div>
+      <dfn>whitespace</dfn>
+      <em>is beautiful</em>
+    </div>
+  `
+  t.equal(result.outerHTML, '<div><dfn>whitespace</dfn> <em>is beautiful</em></div>', 'should have correct output')
+  t.end()
+})
+
+test('space in <pre>', function (t) {
+  t.plan(1)
+  var result = bel`
+    <pre>
+      whitespace is empty
+    </pre>
+  `
+  t.equal(result.outerHTML, '<pre>\n      whitespace is empty\n    </pre>', 'should preserve space')
   t.end()
 })
 


### PR DESCRIPTION
This pull request makes changes to the algorithm for trimming and collapsing space in text nodes.

The goals of the changes are:

1.  Don't mess with space in `<pre>` tags.
2.  Try to better honor how HTML and CSS present space between contiguous, inline text- and non-text elements.
3.  Keep removing the most obviously pointless, space-only text nodes around children elements.

On point number two, an example:

```javascript
bel`
<p>
  To go back to the homepage
  <a href=/>
    click here
  </a>.
</p>
`
```

... currently produces ...

```html
<p>To go back to the homepage<a href=/>click here</a>.</p>
```

Browsers display no space between "homepage" and "click here".


I believe most folks would expect the "natural-looking" HTML template to display as if were pasted directly into HTML, equivalent to:

```html
<p>To go back to the homepage <a href=/>click here</a>.</p>
```

There are various workarounds.  All the ones I've found look regrettably hackish.

```javascript
bel`
<p>
  To go back to the homepage <a href=/>
    click here
  </a>.
</p>
`
```

```javascript
bel`
<p>
  ${document.createTextNode('To go back to the homepage ')}
  <a href=/>
    click here
  </a>.
</p>
`
```

I'm guessing my good friend @yoshuawuyts has it in for all my beautiful whitespace for very valid and impressive performance reasons.  I suppose the situation boils down to something like:

```html
<p><span>some</span> beautiful <code>code</code></p>
```

... is faster to allocate, diff, render, &c. than ...

```html
<p> <span>some</span> beautiful <code>code</code> </p>
```

... due to the pointless text nodes before the `<span>` and after the `<code>`.

This patch tries to let template authors have their whitespace, and let the rendering algos eat it, too.  Essentially, I've tried to write a loose version of the HTML/CSS inter-element space logic into the bel code that reduces whitespace.

The hard call is space between non-text elements:

```javascript
bel`
<p>
  <strong>whitespace</strong>
  <em>is beautiful</em>.
</p>
`
```

Unless we want the algorithm to start looking at the kinds of child elements (or parents) to start making educated guesses about when to drop whitespace, and when to keep it, making this work as expected means a lot of pointless text nodes for non-inline content.  If the perf gain is really that impressive, perhaps it would be worth exposing two template functions, one that munches all the whitespace it can, like XML's `collapse`, and one that leaves it alone, for the HTML/CSS renderer to figure out.