### PR TITLE
fix(raw): server returns an instance of String instead of a primitive

### DIFF
--- a/raw.js
+++ b/raw.js
@@ -14,7 +14,8 @@ function rawCreateElement (tag) {
   }
 
   function server () {
-    var wrapper = String(tag)
+    // eslint-disable-next-line
+    var wrapper = new String(tag)
     wrapper.__encoded = true
     return wrapper
   }

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var bel = require('../')
-var raw = require('../')
+var raw = require('../raw')
 
 test('server side render', function (t) {
   t.plan(2)
@@ -38,6 +38,16 @@ test('unescape html', function (t) {
 
   var expected = '<span>Hello <strong>there</strong></span>'
   var result = raw('<span>Hello <strong>there</strong></span>').toString()
+
+  t.equal(expected, result)
+  t.end()
+})
+
+test('unescape html inside bel', function (t) {
+  t.plan(1)
+
+  var expected = '<span>Hello <strong>there</strong></span>'
+  var result = bel`${raw('<span>Hello <strong>there</strong></span>')}`.toString()
 
   t.equal(expected, result)
   t.end()


### PR DESCRIPTION
Related to #84, fixes a small bug on #86, the var `wrapper` was still a primitive and settings properties on a primitive is a no-op, I'm using an instance of the class String instead