### PR TITLE
Dist raw.js version exposed along with helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "wzrd test/index.js:bundle.js",
     "test": "standard && node test/server.js && browserify test/index.js | tape-run",
-    "bench": "wzrd bench/index.js:bundle.js"
+    "bench": "wzrd bench/index.js:bundle.js",
+    "babel:raw": "babel raw/raw.js --out-file raw/index.js --presets=es2015"    
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,8 @@
     "pelo": "0.0.3"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "browser-process-hrtime": "^0.1.2",
     "browserify": "^14.4.0",
     "electron": "^1.7.4",
@@ -38,5 +41,10 @@
     "tape": "^4.7.0",
     "tape-run": "^3.0.0",
     "wzrd": "^1.4.0"
-  }
+  },
+  "standard": {
+    "ignore": [
+      "raw/index.js"
+    ]      
+  }    
 }

--- a/raw/index.js
+++ b/raw/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var _templateObject = _taggedTemplateLiteral(['<div></div>'], ['<div></div>']);
+
+function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
+
+var bel = require('../');
+
+function rawCreateElement(tag) {
+  if (typeof window !== 'undefined') {
+    return browser();
+  } else {
+    return server();
+  }
+
+  function browser() {
+    var el = bel(_templateObject);
+    el.innerHTML = tag;
+    return toArray(el.childNodes);
+  }
+
+  function server() {
+    var wrapper = new String(tag); // eslint-disable-line no-new-wrappers
+    wrapper.__encoded = true;
+    return wrapper;
+  }
+}
+
+function toArray(arr) {
+  return Array.isArray(arr) ? arr : [].slice.call(arr);
+}
+
+module.exports = rawCreateElement;

--- a/raw/raw.js
+++ b/raw/raw.js
@@ -1,4 +1,4 @@
-var bel = require('.')
+var bel = require('../')
 
 function rawCreateElement (tag) {
   if (typeof window !== 'undefined') {

--- a/test/raw.js
+++ b/test/raw.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var bel = require('../')
-var raw = require('../raw')
+var raw = require('../raw/raw')
 
 test('unescape html', function (t) {
   t.plan(1)

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,6 @@
 var test = require('tape')
 var bel = require('../')
-var raw = require('../raw')
+var raw = require('../raw/raw')
 
 test('server side render', function (t) {
   t.plan(2)


### PR DESCRIPTION
- Exporting `bel/raw` in a dist version so it doesn't explode unexpectedly in different build environments due to substandard export strategy.  
- Updated `tape` tests.
- (Optional) Babel tooling for transpiling the `raw.js` along with a command -  might not be needed and removed, but added for convenience I guess.
