### PR TITLE
Added ^ (caret) for pelo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "hyperx": "^2.3.0",
     "is-electron": "^2.0.0",
-    "pelo": "0.0.3"
+    "pelo": "^0.0.3"
   },
   "devDependencies": {
     "browser-process-hrtime": "^0.1.2",


### PR DESCRIPTION
Or anyone has a valid reason for this missing a caret maybe? 

And so, the PR includes:

- Adding ^ (caret) as I see no reason for semver not picking up a patch (for instance)

