### PR TITLE
Bug fix: ensure whitespace is preserved in textarea

### DIFF
--- a/appendChild.js
+++ b/appendChild.js
@@ -10,7 +10,7 @@ var TEXT_TAGS = [
   'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr'
 ]
 
-var CODE_TAGS = [
+var VERBATIM_TAGS = [
   'code', 'pre', 'textarea'
 ]
 
@@ -61,7 +61,7 @@ module.exports = function appendChild (el, childs) {
         // Trim the child text nodes if the current node isn't a
         // node where whitespace matters.
         if (TEXT_TAGS.indexOf(nodeName) === -1 &&
-          CODE_TAGS.indexOf(nodeName) === -1) {
+          VERBATIM_TAGS.indexOf(nodeName) === -1) {
           value = lastChild.nodeValue
             .replace(leadingNewlineRegex, '')
             .replace(trailingSpaceRegex, '')
@@ -72,7 +72,7 @@ module.exports = function appendChild (el, childs) {
           } else {
             lastChild.nodeValue = value
           }
-        } else if (CODE_TAGS.indexOf(nodeName) === -1) {
+        } else if (VERBATIM_TAGS.indexOf(nodeName) === -1) {
           // The very first node in the list should not have leading
           // whitespace. Sibling text nodes should have whitespace if there
           // was any.
@@ -96,7 +96,7 @@ module.exports = function appendChild (el, childs) {
         // Trim the child text nodes if the current node isn't a
         // text node or a code node
         if (TEXT_TAGS.indexOf(nodeName) === -1 &&
-          CODE_TAGS.indexOf(nodeName) === -1) {
+          VERBATIM_TAGS.indexOf(nodeName) === -1) {
           value = lastChild.nodeValue
             .replace(leadingNewlineRegex, '')
             .replace(trailingNewlineRegex, '')
@@ -110,7 +110,7 @@ module.exports = function appendChild (el, childs) {
           }
         // Trim the child nodes if the current node is not a node
         // where all whitespace must be preserved
-        } else if (CODE_TAGS.indexOf(nodeName) === -1) {
+        } else if (VERBATIM_TAGS.indexOf(nodeName) === -1) {
           value = lastChild.nodeValue
             .replace(leadingSpaceRegex, ' ')
             .replace(leadingNewlineRegex, '')

--- a/appendChild.js
+++ b/appendChild.js
@@ -11,7 +11,7 @@ var TEXT_TAGS = [
 ]
 
 var CODE_TAGS = [
-  'code', 'pre'
+  'code', 'pre', 'textarea'
 ]
 
 module.exports = function appendChild (el, childs) {

--- a/test/elements.js
+++ b/test/elements.js
@@ -151,6 +151,17 @@ test('space in <pre>', function (t) {
   t.end()
 })
 
+test('space in <textarea>', function (t) {
+  t.plan(1)
+  var result = bel`
+    <textarea> Whitespace at beginning 
+      middle
+      and end </textarea>
+  `
+  t.equal(result.outerHTML, '<textarea> Whitespace at beginning \n      middle\n      and end </textarea>', 'should preserve space')
+  t.end()
+})
+
 test('for attribute is set correctly', function (t) {
   t.plan(1)
   var result = bel`<div>


### PR DESCRIPTION
Small fix to ensure whitespace is preserved in textarea. At present, whitespace is being partially stripped.

@yoshuawuyts this fix might need some extra work. I made the smallest change to make the broken test pass, but didn't do more as I'm not familiar with the code. The fix seems slightly wrong, as I had to add "textarea" to the CODE_TAGS array, not TEXT_AREA array.